### PR TITLE
Fix a couple of significant bugs

### DIFF
--- a/rewrite_external_links/middleware.py
+++ b/rewrite_external_links/middleware.py
@@ -33,8 +33,9 @@ class RewriteExternalLinksMiddleware(object):
             return response
 
         h = HTMLParser()
-        html_content_type = "text/html" in response['Content-Type']
+        html_content_type = 'text/html' in response.get('content-type', '')
         start_link = request.META.get('PATH_INFO').startswith(self.external_link_root)
+
         if (response.content and html_content_type and not start_link):
             next = request.path
 
@@ -48,7 +49,10 @@ class RewriteExternalLinksMiddleware(object):
                     link=urlencode(h.unescape(m.group('link')), safe=''),
                     after=m.group('after'),
                 )
-            response.content = self.extlinks.sub(linkrepl, response.content.decode())
+            response.content = self.extlinks.sub(
+                linkrepl,
+                response.content.decode('utf-8')
+            )
             return response
         else:
             return response

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,7 +13,7 @@ class TestRewriteExternalLinksMiddleware(TestCase):
         self.request = MagicMock()
         self.content_type = 'text/html'
         self.link = 'http://ΣxamplΣ.com'  # get some unicode in there
-        self.content = '<a    href="{}"></a>'.format(self.link).encode()
+        self.content = '<a    href="{}"></a>'.format(self.link).encode('utf-8')
 
     def test_no_response_content(self):
         """When response has no content the middleware does nothing."""

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -11,7 +11,7 @@ class TestRewriteExternalLinksMiddleware(TestCase):
         self.middleware = RewriteExternalLinksMiddleware()
         self.request = MagicMock()
         self.content_type = 'text/html'
-        self.link = 'http://example.com'
+        self.link = 'http://ΣxamplΣ.com'  # get some unicode in there
         self.content = '<a    href="{}"></a>'.format(self.link).encode()
 
     def test_no_response_content(self):
@@ -36,6 +36,16 @@ class TestRewriteExternalLinksMiddleware(TestCase):
         """When response `Content-Type` is not `text/html` the middleware does nothing."""
         content_type = 'application/thraud+xml'
         response = HttpResponse(content=self.content, content_type=content_type)
+        processed_response = self.middleware.process_response(
+            request=self.request,
+            response=response,
+        )
+        self.assertEqual(processed_response.content, self.content)
+
+    def test_missing_content_type(self):
+        """When response `Content-Type` is missing, the middleware does nothing."""
+        response = HttpResponse(content=self.content)
+        del response['content-type']
         processed_response = self.middleware.process_response(
             request=self.request,
             response=response,

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from django.http.response import FileResponse, HttpResponse
 from django.template.defaultfilters import urlencode
 from django.test import TestCase

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -12,8 +12,8 @@ class TestRewriteExternalLinksMiddleware(TestCase):
         self.middleware = RewriteExternalLinksMiddleware()
         self.request = MagicMock()
         self.content_type = 'text/html'
-        self.link = 'http://ΣxamplΣ.com'  # get some unicode in there
-        self.content = '<a    href="{}"></a>'.format(self.link).encode('utf-8')
+        self.link = u'http://ΣxamplΣ.com'  # get some unicode in there
+        self.content = u'<a    href="{}"></a>'.format(self.link).encode('utf-8')
 
     def test_no_response_content(self):
         """When response has no content the middleware does nothing."""


### PR DESCRIPTION
- Handle non-ASCII characters in the web page properly.  (How has *that* not come up before?)
- Avoid odd problems when the response object doesn't have a `Content-Type` attribute yet

@incuna/backend review please?