### PR TITLE
Don't reverse 'external_link' at runtime.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,5 @@ env:
   matrix:
     - DJANGO='django>=1.8,<1.9'
     - DJANGO='django>=1.9,<1.10'
-    - DJANGO='--upgrade --pre django'
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: DJANGO='upgrade --pre django'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.0 (Upcoming)
+
+* Don't reverse 'external_link' at runtime.
+
 ## v1.0.3
 
 * Set the response's content length correctly after editing the content.

--- a/rewrite_external_links/middleware.py
+++ b/rewrite_external_links/middleware.py
@@ -26,22 +26,22 @@ class RewriteExternalLinksMiddleware(object):
         (?P<link>https?://{}[^'">]*)  # href link
         (?P<after>[^>]*)  # content after the href attribute to the closing bracket `>`
     '''.format(safe_urls), re.VERBOSE)
-    external_link_root = reverse('external_link')
 
     def process_response(self, request, response):
+        external_link_root = reverse('external_link')
         if response.streaming:
             return response
 
         h = HTMLParser()
         html_content_type = 'text/html' in response.get('content-type', '')
-        start_link = request.META.get('PATH_INFO').startswith(self.external_link_root)
+        start_link = request.META.get('PATH_INFO').startswith(external_link_root)
 
         if (response.content and html_content_type and not start_link):
             next = request.path
 
             def linkrepl(m):
                 return '{before}{root}?link={link}&next={next}{after}'.format(
-                    root=self.external_link_root,
+                    root=external_link_root,
                     next=next,
                     before=m.group('before'),
                     # unescape the link before encoding it to ensure entities

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from rewrite_external_links import get_version
 
 description = (
     'Rewrite all external (off-site) links to go via a message page, '
-    + 'using a middleware class.'
+    'using a middleware class.'
 )
 
 setup(


### PR DESCRIPTION
Allow to use site with suffixes:
 - site.example/suffix/

When a path is declared as a base in nginx like `site.example/en`, `reverse` evaluated at runtime returns `/external-link`. Instead we need `reverse` to return `/suffix/external-link`

I couldn't use 'reverse_lazy' as startswith requires a string not a `__proxy__`.
I didn't find a suitable way of testing it but I have been relting on current tests.