### PR TITLE
Use request.path to compare start link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1
+
+* Use request.path to compare start link.
+
 ## v1.1.0
 
 * Don't reverse 'external_link' at runtime.

--- a/rewrite_external_links/__init__.py
+++ b/rewrite_external_links/__init__.py
@@ -1,4 +1,4 @@
-__version__ = (1, 1, 0)
+__version__ = (1, 1, 1)
 
 
 def get_version():

--- a/rewrite_external_links/middleware.py
+++ b/rewrite_external_links/middleware.py
@@ -34,7 +34,7 @@ class RewriteExternalLinksMiddleware(object):
 
         h = HTMLParser()
         html_content_type = 'text/html' in response.get('content-type', '')
-        start_link = request.META.get('PATH_INFO').startswith(external_link_root)
+        start_link = request.path.startswith(external_link_root)
 
         if (response.content and html_content_type and not start_link):
             next = request.path


### PR DESCRIPTION
If `SCRIPT_NAME` is set then `external_link_root` will include the
`SCRIPT_NAME` part however `PATH_INFO` will not.
